### PR TITLE
Fix minor mode detection

### DIFF
--- a/ryo-modal.el
+++ b/ryo-modal.el
@@ -63,8 +63,7 @@ add :norepeat t as a keyword."
   (mapcar (lambda (mode)
             (eval (intern-soft (concat "ryo-" (symbol-name mode) "-map"))))
           (seq-filter (lambda (elt) (or (derived-mode-p elt)
-                                        (when (boundp elt)
-                                          (and (boundp elt) (symbol-value elt)))))
+                                        (and (boundp elt) (symbol-value elt))))
                       ryo-modal-mode-keymaps)))
 
 (defun ryo-modal-maybe-store-last-command ()

--- a/ryo-modal.el
+++ b/ryo-modal.el
@@ -63,7 +63,8 @@ add :norepeat t as a keyword."
   (mapcar (lambda (mode)
             (eval (intern-soft (concat "ryo-" (symbol-name mode) "-map"))))
           (seq-filter (lambda (elt) (or (derived-mode-p elt)
-                                        (and `(boundp ',elt) elt)))
+                                        (when (boundp elt)
+                                          (and (boundp elt) (symbol-value elt)))))
                       ryo-modal-mode-keymaps)))
 
 (defun ryo-modal-maybe-store-last-command ()


### PR DESCRIPTION
This should fix the problem from my last try to detect minor mode. I have restarted Emacs several times when testing this, and it seems to activate the correct bindings when jumping between different buffers. Again, thanks for the awesome package! 