### PR TITLE
Adds the "hydra+" keyword

### DIFF
--- a/README.org
+++ b/README.org
@@ -122,7 +122,6 @@ In order to create a hydra, bind it to a key using =ryo-modal-key= or =ryo-modal
    "SPC g" :hydra
    '(hydra-git ()
                "A hydra for git!"
-               ("g" magit-status "magit" :color blue)
                ("j" git-gutter:next-hunk "next")
                ("k" git-gutter:previous-hunk "previous")
                ("d" git-gutter:popup-hunk "diff")
@@ -130,6 +129,18 @@ In order to create a hydra, bind it to a key using =ryo-modal-key= or =ryo-modal
                ("r" git-gutter:revert-hunk "revert")
                ("m" git-gutter:mark-hunk "mark")
                ("q" nil "cancel" :color blue)))
+#+END_SRC
+
+*** Adding to preexisting hydras
+
+If, for example, you wanted to add the =magit-status= function to the previously created =hydra-git= example, you would do the following:
+
+#+BEGIN_SRC emacs-lisp
+  (ryo-modal-key
+   "SPC g" :hydra+
+   '(hydra-git ()
+               "A hydra for git!"
+               ("g" magit-status "magit" :color blue)))
 #+END_SRC
 
 ** Defining "normal mode" keys which enter =ryo-modal=

--- a/ryo-modal.el
+++ b/ryo-modal.el
@@ -116,7 +116,7 @@ keymap       Similarly to list, each keybinding of provided keymap
 :hydra       If you have hydra installed, a new hydra will be created and
              bound to KEY.  The first element of ARGS should be a list
              containing the arguments sent to `defhydra'.
-:hydra+      If you have hydra installed, this will add heads to a pre-existing hydra.
+:hydra+      If you have hydra installed, this will add heads to a preexisting hydra.
              As with the `:hydra' keyword, the first element of ARGS should be a list
              containing the arguments sent to `defhydra+'.
 

--- a/ryo-modal.el
+++ b/ryo-modal.el
@@ -116,6 +116,9 @@ keymap       Similarly to list, each keybinding of provided keymap
 :hydra       If you have hydra installed, a new hydra will be created and
              bound to KEY.  The first element of ARGS should be a list
              containing the arguments sent to `defhydra'.
+:hydra+      If you have hydra installed, this will add heads to a pre-existing hydra.
+             As with the `:hydra' keyword, the first element of ARGS should be a list
+             containing the arguments sent to `defhydra+'.
 
 ARGS should be of the form [:keyword option]... if TARGET is a kbd-string
 or a command.  The following keywords exist:
@@ -169,6 +172,9 @@ make sure the name of the created command is unique."
    ((and (require 'hydra nil t)
          (equal target :hydra))
     (apply #'ryo-modal-key `(,key ,(eval `(defhydra ,@(car args))) ,@(cdr args))))
+   ((and (require 'hydra nil t)
+         (equal target :hydra+))
+    (apply #'ryo-modal-key `(,key ,(eval `(defhydra+ ,@(car args))) ,@(cdr args))))
    ((and (stringp target) (keymapp (key-binding (kbd target))))
     (let* ((binding (key-binding (kbd target)))
            (map-to-translate (if (symbolp binding) (symbol-function binding) binding)))


### PR DESCRIPTION
This will add the `defhydra+` functionality, allowing users to add heads to preexisting hydras; tested, and it works! 😺 I also updated the `README`!