### PR TITLE
make ryo-modal-repeat remember prefix-arg

### DIFF
--- a/ryo-modal.el
+++ b/ryo-modal.el
@@ -44,6 +44,7 @@ Major mode specific bindings will be bound to ryo-<major-mode>-map instead.")
 It is more convenient to view this using `ryo-modal-bindings'.")
 
 (defvar ryo-modal--last-command nil)
+(defvar ryo-modal--last-command-prefix-arg nil)
 
 (defun ryo-modal-repeat ()
   "Repeat last executed command in `ryo-modal-map' (or major mode variant).
@@ -52,6 +53,7 @@ If you do not want a command to be remembered by `ryo-modal-repeat',
 add :norepeat t as a keyword."
   (interactive)
   (when ryo-modal--last-command
+    (setf current-prefix-arg ryo-modal--last-command-prefix-arg)
     (command-execute ryo-modal--last-command nil nil t)))
 
 (defvar ryo-modal--non-repeating-commands '(ryo-modal-repeat))
@@ -77,9 +79,10 @@ add :norepeat t as a keyword."
     (let ((cmd (lookup-key (apply 'append ryo-modal-mode-map
                                   (ryo-modal-derived-keymaps))
                            (this-command-keys))))
-      (if (and (commandp cmd)
-               (not (member cmd ryo-modal--non-repeating-commands)))
-          (setq ryo-modal--last-command cmd)))))
+      (when (and (commandp cmd)
+                 (not (member cmd ryo-modal--non-repeating-commands)))
+        (setq ryo-modal--last-command-prefix-arg last-prefix-arg)
+        (setq ryo-modal--last-command cmd)))))
 
 (defun ryo-modal--translate-keymap (keymap)
   "Translate keymap to equivalent list of pairs (key command).


### PR DESCRIPTION
Hi,

I started using ryo-modal recently and it's a great package.

This pull request changes the behavior of `ryo-modal-repeat` when previous command is applied with prefix argument.

Before the change, ryo-modal-repeat will call previous command but discards the prefix argument. This makes the result surprising sometimes. E.g., if we set `(ryo-modal-keys ("k" kill-line))`, then `C-u` `-1` `k` (which kills lines backwards), then `ryo-modal-repeat`, we would expect that it continues to kill lines backwards. But since the prefix argument is discarded, the result is "Kill the rest of the current line".

The patch fixes that by remembering the prefix argument by `ryo-modal--last-command-prefix-arg`

It works fine for me. I think it's reasonable to make it the default behavior. But if you have other considerations, maybe consider adding something like `(defcustom  ryo-modal--remember-last-command-prefix-arg nil)`?

It's great to be able to hear back from you.

Thanks!